### PR TITLE
fix(feeds): avoid updating inexistent nss_packages feed

### DIFF
--- a/ax3600.config
+++ b/ax3600.config
@@ -111,5 +111,5 @@ CONFIG_ATH11K_DEBUGFS_STA=n
 CONFIG_ATH11K_THERMAL=n
 
 ## Prevent Custom Feeds
-CONFIG_FEED_nss=n
+CONFIG_FEED_nss_packages=n
 CONFIG_FEED_sqm_scripts_nss=n


### PR DESCRIPTION
According to upstream (https://github.com/qosmio/openwrt-ipq/blob/main-nss/feeds.conf.default#L5-L6):
```
src-git nss_packages https://github.com/qosmio/nss-packages.git;NSS-12.5-K6.x
src-git sqm_scripts_nss https://github.com/qosmio/sqm-scripts-nss.git
```

This results in the following `apk update` behavior: 
```
WARNING: updating and opening https://downloads.openwrt.org/snapshots/packages/aarch64_cortex-a53/nss_packages/packages.adb: unexpected end of file
```

This may relate to the feed distinguished as `nss_packages` instead of `nss`.

This patch adjusts that.